### PR TITLE
学習テストもローカルCIで実行をできるようにした

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,9 +1,8 @@
 pre-push:
   parallel: true
   commands:    
-    rspec:
-    # 学習用テストはプロダクトのバグには関係ないので外している
-      run: bundle exec rspec  --exclude-pattern "spec/research/*_spec.rb" 
+    rspec:    
+      run: bundle exec rspec 
       fail_text: "RSpec tests failed"
     rubocop:
       run: bundle exec rubocop


### PR DESCRIPTION
今まではライブラリーの調査目的でテストを通すことがめんどうだったが、やはり学習テストもCIしたほうがいいので